### PR TITLE
Refactor the service name to support multiple plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Internal changes
+- Refactor the service name to support multiple plugins
+
 ## [1.0.0] - 2016-10-12
 ### Added
 - Prepend the subject of a Swiftmailer message with a string
 - Prepend the body of a Swiftmailer message with a rendered template content
 
+[Unreleased]: https://github.com/pixelart/swiftmailer-manipulator-bundle/compare/1.0.0...HEAD
 [1.0.0]: https://github.com/pixelart/swiftmailer-manipulator-bundle/compare/d413443...1.0.0

--- a/DependencyInjection/PixelartSwiftmailerManipulatorExtension.php
+++ b/DependencyInjection/PixelartSwiftmailerManipulatorExtension.php
@@ -36,26 +36,33 @@ class PixelartSwiftmailerManipulatorExtension extends Extension
     {
         if (!empty($mailer['prepend_subject']) || !empty($mailer['prepend_body'])) {
             $container->setParameter(
-                sprintf('pixelart_swiftmailer_manipulator.mailer.%s.prepend_subject', $name),
+                sprintf('pixelart_swiftmailer_manipulator.mailer.%s.manipulator.prepend_subject', $name),
                 !empty($mailer['prepend_subject']) ? $mailer['prepend_subject'] : null
             );
             $container->setParameter(
-                sprintf('pixelart_swiftmailer_manipulator.mailer.%s.prepend_body', $name),
+                sprintf('pixelart_swiftmailer_manipulator.mailer.%s.manipulator.prepend_body', $name),
                 !empty($mailer['prepend_body']) ? $mailer['prepend_body'] : null
             );
 
-            $definitionDecorator = new DefinitionDecorator('pixelart_swiftmailer_manipulator.plugin.abstract');
+            $definitionDecorator = new DefinitionDecorator(
+                'pixelart_swiftmailer_manipulator.plugin.manipulator.abstract'
+            );
+
             $container
                 ->setDefinition(
-                    sprintf('pixelart_swiftmailer_manipulator.mailer.%s.plugin', $name),
+                    sprintf('pixelart_swiftmailer_manipulator.mailer.%s.plugin.manipulator', $name),
                     $definitionDecorator
                 )
-                ->addArgument(sprintf('%%pixelart_swiftmailer_manipulator.mailer.%s.prepend_subject%%', $name))
-                ->addArgument(sprintf('%%pixelart_swiftmailer_manipulator.mailer.%s.prepend_body%%', $name))
+                ->addArgument(
+                    sprintf('%%pixelart_swiftmailer_manipulator.mailer.%s.manipulator.prepend_subject%%', $name)
+                )
+                ->addArgument(
+                    sprintf('%%pixelart_swiftmailer_manipulator.mailer.%s.manipulator.prepend_body%%', $name)
+                )
             ;
 
             $container
-                ->getDefinition(sprintf('pixelart_swiftmailer_manipulator.mailer.%s.plugin', $name))
+                ->getDefinition(sprintf('pixelart_swiftmailer_manipulator.mailer.%s.plugin.manipulator', $name))
                 ->addTag(sprintf('swiftmailer.%s.plugin', $name))
             ;
         }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -14,7 +14,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="pixelart_swiftmailer_manipulator.plugin.abstract"
+        <service id="pixelart_swiftmailer_manipulator.plugin.manipulator.abstract"
                 class="Pixelart\Bundle\SwiftmailerManipulatorBundle\Swift\Plugins\ManipulatorPlugin"
                 abstract="true" public="false">
             <argument type="service" id="templating" />

--- a/Tests/DependencyInjection/PixelartSwiftmailerManipulatorExtensionTest.php
+++ b/Tests/DependencyInjection/PixelartSwiftmailerManipulatorExtensionTest.php
@@ -35,7 +35,7 @@ class PixelartSwiftmailerManipulatorExtensionTest extends \PHPUnit_Framework_Tes
     {
         $container = $this->loadContainerFromFile('empty', $type);
 
-        $container->get('pixelart_swiftmailer_manipulator.mailer.default.plugin');
+        $container->get('pixelart_swiftmailer_manipulator.mailer.default.plugin.manipulator');
     }
 
     /**
@@ -47,17 +47,17 @@ class PixelartSwiftmailerManipulatorExtensionTest extends \PHPUnit_Framework_Tes
 
         self::assertSame(
             ['swiftmailer.default.plugin' => [[]]],
-            $container->getDefinition('pixelart_swiftmailer_manipulator.mailer.default.plugin')->getTags()
+            $container->getDefinition('pixelart_swiftmailer_manipulator.mailer.default.plugin.manipulator')->getTags()
         );
 
         self::assertSame(
             '[TESTSYSTEM!]',
-            $container->getParameter('pixelart_swiftmailer_manipulator.mailer.default.prepend_subject')
+            $container->getParameter('pixelart_swiftmailer_manipulator.mailer.default.manipulator.prepend_subject')
         );
 
         self::assertSame(
             'swiftmailer/prepend_body.txt.twig',
-            $container->getParameter('pixelart_swiftmailer_manipulator.mailer.default.prepend_body')
+            $container->getParameter('pixelart_swiftmailer_manipulator.mailer.default.manipulator.prepend_body')
         );
     }
 
@@ -70,15 +70,15 @@ class PixelartSwiftmailerManipulatorExtensionTest extends \PHPUnit_Framework_Tes
 
         self::assertSame(
             ['swiftmailer.default.plugin' => [[]]],
-            $container->getDefinition('pixelart_swiftmailer_manipulator.mailer.default.plugin')->getTags()
+            $container->getDefinition('pixelart_swiftmailer_manipulator.mailer.default.plugin.manipulator')->getTags()
         );
 
         self::assertSame(
             '[TESTSYSTEM!]',
-            $container->getParameter('pixelart_swiftmailer_manipulator.mailer.default.prepend_subject')
+            $container->getParameter('pixelart_swiftmailer_manipulator.mailer.default.manipulator.prepend_subject')
         );
 
-        self::assertNull($container->getParameter('pixelart_swiftmailer_manipulator.mailer.default.prepend_body'));
+        self::assertNull($container->getParameter('pixelart_swiftmailer_manipulator.mailer.default.manipulator.prepend_body'));
     }
 
     /**
@@ -90,17 +90,17 @@ class PixelartSwiftmailerManipulatorExtensionTest extends \PHPUnit_Framework_Tes
 
         self::assertSame(
             ['swiftmailer.main_mailer.plugin' => [[]]],
-            $container->getDefinition('pixelart_swiftmailer_manipulator.mailer.main_mailer.plugin')->getTags()
+            $container->getDefinition('pixelart_swiftmailer_manipulator.mailer.main_mailer.plugin.manipulator')->getTags()
         );
 
         self::assertSame(
             '[TESTSYSTEM!]',
-            $container->getParameter('pixelart_swiftmailer_manipulator.mailer.main_mailer.prepend_subject')
+            $container->getParameter('pixelart_swiftmailer_manipulator.mailer.main_mailer.manipulator.prepend_subject')
         );
 
         self::assertSame(
             'swiftmailer/prepend_body.txt.twig',
-            $container->getParameter('pixelart_swiftmailer_manipulator.mailer.main_mailer.prepend_body')
+            $container->getParameter('pixelart_swiftmailer_manipulator.mailer.main_mailer.manipulator.prepend_body')
         );
     }
 
@@ -114,49 +114,49 @@ class PixelartSwiftmailerManipulatorExtensionTest extends \PHPUnit_Framework_Tes
         // first mailer
         self::assertSame(
             ['swiftmailer.first_mailer.plugin' => [[]]],
-            $container->getDefinition('pixelart_swiftmailer_manipulator.mailer.first_mailer.plugin')->getTags()
+            $container->getDefinition('pixelart_swiftmailer_manipulator.mailer.first_mailer.plugin.manipulator')->getTags()
         );
 
         self::assertSame(
             '[TESTSYSTEM 1!]',
-            $container->getParameter('pixelart_swiftmailer_manipulator.mailer.first_mailer.prepend_subject')
+            $container->getParameter('pixelart_swiftmailer_manipulator.mailer.first_mailer.manipulator.prepend_subject')
         );
 
         self::assertSame(
             'swiftmailer/prepend_body_1.txt.twig',
-            $container->getParameter('pixelart_swiftmailer_manipulator.mailer.first_mailer.prepend_body')
+            $container->getParameter('pixelart_swiftmailer_manipulator.mailer.first_mailer.manipulator.prepend_body')
         );
 
         // second mailer
         self::assertSame(
             ['swiftmailer.secondary_mailer.plugin' => [[]]],
-            $container->getDefinition('pixelart_swiftmailer_manipulator.mailer.secondary_mailer.plugin')->getTags()
+            $container->getDefinition('pixelart_swiftmailer_manipulator.mailer.secondary_mailer.plugin.manipulator')->getTags()
         );
 
         self::assertSame(
             '[TESTSYSTEM 2!]',
-            $container->getParameter('pixelart_swiftmailer_manipulator.mailer.secondary_mailer.prepend_subject')
+            $container->getParameter('pixelart_swiftmailer_manipulator.mailer.secondary_mailer.manipulator.prepend_subject')
         );
 
         self::assertSame(
             'swiftmailer/prepend_body_2.txt.twig',
-            $container->getParameter('pixelart_swiftmailer_manipulator.mailer.secondary_mailer.prepend_body')
+            $container->getParameter('pixelart_swiftmailer_manipulator.mailer.secondary_mailer.manipulator.prepend_body')
         );
 
         // third mailer
         self::assertSame(
             ['swiftmailer.third_mailer.plugin' => [[]]],
-            $container->getDefinition('pixelart_swiftmailer_manipulator.mailer.third_mailer.plugin')->getTags()
+            $container->getDefinition('pixelart_swiftmailer_manipulator.mailer.third_mailer.plugin.manipulator')->getTags()
         );
 
         self::assertSame(
             '[TESTSYSTEM 3!]',
-            $container->getParameter('pixelart_swiftmailer_manipulator.mailer.third_mailer.prepend_subject')
+            $container->getParameter('pixelart_swiftmailer_manipulator.mailer.third_mailer.manipulator.prepend_subject')
         );
 
         self::assertSame(
             'swiftmailer/prepend_body_3.txt.twig',
-            $container->getParameter('pixelart_swiftmailer_manipulator.mailer.third_mailer.prepend_body')
+            $container->getParameter('pixelart_swiftmailer_manipulator.mailer.third_mailer.manipulator.prepend_body')
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | internal only |
| Deprecations? | no |
| Fixed tickets | - |
| Related issues/PRs | - |
| License | MIT |
#### What's in this PR?

Refactor the service name fro generic `.plugin` suffix to `.plugin.manipulator`.
#### Why?

To support multiple swiftmailer plugins
#### BC Breaks/Deprecations

Only if anyone replaced the service. But with the lifetime of the project, this is not the case.
