### PR TITLE
Make Travis build only on master and test/* branches on push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ cache:
   directories:
     - $HOME/.composer/cache
 
+branches:
+  only:
+    - master
+    - /^test\/.*$/
+
 matrix:
   include:
     - php: 5.4


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | - |
| Related issues/PRs | - |
| License | MIT |
#### What's in this PR?

Travis is now restricted to build only on `master` and `test/*` branches on push. On PR builds are still made every time, when pushed if a PR exists.
#### Why?

Pull requests from branches in the repository itself are creating doubled Travis builds and so blocking 10 build workers instead of 5. This is unnecessary.
##### Why `test/*` branches?

If there are something you really want to test through Travis without creating a PR, name the branch `test/whatever` and push. If you want to create a pull request later, simply rename the branch.
