### PR TITLE
Add Style CI for code style testing

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -16,9 +16,21 @@ $finder = Symfony\CS\Finder::create()
     ->in(__DIR__)
 ;
 
+$header = <<<EOF
+This file is part of the pixelart Swiftmailer manipulator bundle.
+
+(c) pixelart GmbH
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+EOF;
+
+Symfony\CS\Fixer\Contrib\HeaderCommentFixer::setHeader($header);
+
 return Symfony\CS\Config::create()
     ->fixers([
         'combine_consecutive_unsets',
+        'header_comment',
         'no_useless_else',
         'no_useless_return',
         'ordered_use',

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,0 +1,14 @@
+preset: symfony
+
+enabled:
+    - combine_consecutive_unsets
+    - no_useless_else
+    - no_useless_return
+    - ordered_use
+    - php_unit_construct
+    - php_unit_dedicate_assert
+    - php_unit_strict
+    - phpdoc_order
+    - short_array_syntax
+    - strict
+    - strict_param

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Swiftmailer Manipulator for Symfony
 [![Build Status](https://travis-ci.org/pixelart/swiftmailer-manipulator-bundle.svg?branch=master)](https://travis-ci.org/pixelart/swiftmailer-manipulator-bundle)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/pixelart/swiftmailer-manipulator-bundle/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/pixelart/swiftmailer-manipulator-bundle/?branch=master)
 [![Code Coverage](https://scrutinizer-ci.com/g/pixelart/swiftmailer-manipulator-bundle/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/pixelart/swiftmailer-manipulator-bundle/?branch=master)
+[![Code Style](https://styleci.io/repos/70606516/shield?style=flat)](https://styleci.io/repos/70606516)
 
 Sometimes you have staging systems, where you can't install [MailHog] and
 using `delivery_address` or `disable_delivery` on the SwiftmailerBundle is


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | - |
| Related issues/PRs | - |
| License | MIT |
#### What's in this PR?

Adds StyleCI to have a continuous code style checking. Config is the same as the `php-cs-fixer` executed locally.
